### PR TITLE
Exiv2 version 0.28.2

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        EXIV2TAG: [v0.28.1]
+        EXIV2TAG: [v0.28.2]
     runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/website/master/news.xml
+++ b/website/master/news.xml
@@ -2,6 +2,20 @@
 <news>
 
  <newsitem>
+  <date>2024-02-13</date>
+  <title>Exiv2 v0.28.2</title>
+  <abstract>Exiv2 v0.28.2</abstract>
+  <desc>
+   <ol>
+    <li>Minor bugs and fixes</li>
+    <li>Fix for CVE-2024-24826: out-of-bounds read in QuickTimeVideo::NikonTagsDecoder.</li>
+    <li>Fix for CVE-2024-25112: denial of service due to unbounded recursion in QuickTimeVideo::multipleEntriesDecoder.</li>
+   </ol>
+   <p>More details: <a href="https://github.com/Exiv2/exiv2/issues/2914" _target="_blank">Change List</a></p>
+  </desc>
+ </newsitem>
+
+ <newsitem>
   <date>2023-11-06</date>
   <title>Exiv2 v0.28.1</title>
   <abstract>Exiv2 v0.28.1</abstract>


### PR DESCRIPTION
Add version 0.28.2 to the [exiv2.org](https://exiv2.org/) website.