### PR TITLE
Exiv2 version 0.28.3

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        EXIV2TAG: [v0.28.2]
+        EXIV2TAG: [v0.28.3]
     runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/website/master/news.xml
+++ b/website/master/news.xml
@@ -2,6 +2,19 @@
 <news>
 
  <newsitem>
+  <date>2024-07-08</date>
+  <title>Exiv2 v0.28.3</title>
+  <abstract>Exiv2 v0.28.3</abstract>
+  <desc>
+   <ol>
+    <li>Minor bugs and fixes</li>
+    <li>Fix for CVE-2024-39695: out-of-bounds read in AsfVideo::streamProperties.</li>
+   </ol>
+   <p>More details: <a href="https://github.com/Exiv2/exiv2/issues/3008" _target="_blank">Change List</a></p>
+  </desc>
+ </newsitem>
+
+ <newsitem>
   <date>2024-02-13</date>
   <title>Exiv2 v0.28.2</title>
   <abstract>Exiv2 v0.28.2</abstract>


### PR DESCRIPTION
Add version 0.28.3 to the [exiv2.org](https://exiv2.org/) website.