### PR TITLE
Exiv2 version 0.28.6

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        EXIV2TAG: [v0.28.5]
+        EXIV2TAG: [v0.28.6]
     runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/website/master/news.xml
+++ b/website/master/news.xml
@@ -2,6 +2,20 @@
 <news>
 
  <newsitem>
+  <date>2025-08-29</date>
+  <title>Exiv2 v0.28.6</title>
+  <abstract>Exiv2 v0.28.6</abstract>
+  <desc>
+   <ol>
+    <li>Security fix</li>
+    <li>Fix for CVE-2025-54080: Out-of-bounds read in Exiv2::EpsImage::writeMetadata() via crafted EPS file</li>
+    <li>Fix for CVE-2025-55304: Quadratic performance in ICC profile parsing in JpegBase::readMetadata</li>
+   </ol>
+   <p>More details: <a href="https://github.com/Exiv2/exiv2/issues/3323" _target="_blank">Change List</a></p>
+  </desc>
+ </newsitem>
+
+ <newsitem>
   <date>2025-02-21</date>
   <title>Exiv2 v0.28.5</title>
   <abstract>Exiv2 v0.28.5</abstract>


### PR DESCRIPTION
Add version 0.28.6 to the [exiv2.org](https://exiv2.org/) website.