### PR TITLE
List all files before deploy, to help with debugging

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -94,6 +94,11 @@ jobs:
         if: contains(matrix.EXIV2TAG, 'RC')
         run: sed -E '/PreRelease.png/s/\/\*|\*\//  /g' -i $EXIV2WEB/html/include/exiv2.css
 
+      - name: List all files before deploy
+        run: |
+          cd $EXIV2WEB
+          find . -type f
+
       - name: Deploy static content for exiv2.org
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main' && !contains(matrix.EXIV2TAG, 'RC')


### PR DESCRIPTION
The download links on https://exiv2.org/download.html aren't working, probably because the filenames are wrong. Hopefully this will help to debug the problem.