### PR TITLE
Don't delete the html/builds directory

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -88,7 +88,7 @@ jobs:
           done
 
           # Cleanup
-          rm -fr /tmp/artifacts.txt $EXIV2WEB/html/releases $EXIV2WEB/html/builds
+          rm -fr /tmp/artifacts.txt $EXIV2WEB/html/releases
 
       - name: Add CSS marker if pre-release
         if: contains(matrix.EXIV2TAG, 'RC')


### PR DESCRIPTION
I think this is why the links on https://exiv2.org/download.html don't work. We're deleting the `html/builds` directory, which is where they're copied to by the `downloads.sh` script.