### PR TITLE
Exiv2 version 0.28.7

### DIFF
--- a/.github/workflows/exiv2.org.yml
+++ b/.github/workflows/exiv2.org.yml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        EXIV2TAG: [v0.28.6]
+        EXIV2TAG: [v0.28.7]
     runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/website/master/news.xml
+++ b/website/master/news.xml
@@ -2,6 +2,19 @@
 <news>
 
  <newsitem>
+  <date>2025-08-31</date>
+  <title>Exiv2 v0.28.7</title>
+  <abstract>Exiv2 v0.28.7</abstract>
+  <desc>
+   <ol>
+    <li>Fix for ABI incompatibility that was accidentally introduced in v0.28.6</li>
+    <li>https://github.com/Exiv2/exiv2/issues/3376</li>
+   </ol>
+   <p>More details: <a href="https://github.com/Exiv2/exiv2/issues/3323" _target="_blank">Change List</a></p>
+  </desc>
+ </newsitem>
+
+ <newsitem>
   <date>2025-08-29</date>
   <title>Exiv2 v0.28.6</title>
   <abstract>Exiv2 v0.28.6</abstract>


### PR DESCRIPTION
Add version 0.28.7 to the [exiv2.org](https://exiv2.org/) website.